### PR TITLE
docs: improve README with typo fixes and better structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # See Image Diff
-It takes two folders, *base* and *current* full of wonderful images with same **names** and ganarates a **diff** folder in given destination folder with the same **names**. Also, it generates a **JSON** blob with the comparison info and a *neat* web app to navigate through this image files. This uses [jimp](https://github.com/oliver-moran/jimp) to compare the images which uses an awesome library [pixelmatch](https://github.com/mapbox/pixelmatch).
+
+It takes two folders, *base* and *current* full of wonderful images with the same **names** and generates a **diff** folder in a given destination folder with the same **names**. Also, it generates a **JSON** blob with the comparison info and a *neat* web app to navigate through these image files. This uses [jimp](https://github.com/oliver-moran/jimp) to compare the images, which in turn uses an awesome library called [pixelmatch](https://github.com/mapbox/pixelmatch).
 
 ![Test & Deploy](https://github.com/RaviDasari/see-image-diff/workflows/Test%20&%20Deploy/badge.svg)
 [![npm version](https://img.shields.io/npm/v/see-image-diff.svg)](https://www.npmjs.com/package/see-image-diff)
 
-
 [![Watch the video](https://github.com/RaviDasari/see-image-diff/blob/master/web/assets/see-image-diff.png)](https://youtu.be/EvdLGdjXnQQ)
 
+## Installation
 
-To install...
-```
+```bash
 npm install see-image-diff
 
-(or)
+# or
 
 yarn add see-image-diff
 ```
 
-Usage...
+## Usage
 
-```
+```text
 Image comparison utility
 
   It takes two folders, base and current full of images with same names and     
-  ganarates a diff folder in given destination location with the same names.    
+  generates a diff folder in given destination location with the same names.    
   Also, it generates a JSON blob and a neat web app to navigate through this    
   image files. It uses jimp npm module to compare the images.                   
 
@@ -39,19 +39,17 @@ Options
                               files. Can contain a thumbnail folder with same image names.                  
   -c, --currentDir folder     Current images folder used for comparison. Should be flat list of image       
                               files. Can contain a thumbnail folder with same image names.                  
-  -d, --destDir folder        Destination folder to same all the diff images. Utility will overwrite any    
-                              existing files in this locaiton.                                              
+  -d, --destDir folder        Destination folder to save all the diff images. Utility will overwrite any    
+                              existing files in this location.                                              
   -t, --threshold number      (Optional) Defaults to 0.1. Ranges 0-1.                                       
   --reportFileName filename   (Optional) Defaults to report.json.                                           
   -h, --help                  Print usage                                                                   
-
 ```
-
 
 ## Roadmap
 
-* Refactor UI navbar
-* Fix image viewer issues
-* Add zoom option to image viewer
-* Provider a filer server to upload and to manage multiple versions - Requires a lot of effort so might not be coming soon.
-* Need contributors to update the deps and maintain!
+- Refactor UI navbar
+- Fix image viewer issues
+- Add zoom option to image viewer
+- Provide a file server to upload and manage multiple versions — requires a lot of effort, so might not be coming soon
+- Need contributors to update the deps and maintain!


### PR DESCRIPTION
## Summary

This PR improves the README documentation with various fixes and enhancements.

## Changes

### Typos Fixed
- "ganarates" → "generates" (appeared in 2 places)
- "locaiton" → "location"
- "same all" → "save all" (in destDir description)
- "filer server" → "file server"
- "Provider" → "Provide"

### Structure Improvements
- Added `## Installation` heading (was "To install...")
- Added `## Usage` heading (was "Usage...")
- Added blank line after the H1 title for better readability
- Changed bullet points in Roadmap from `*` to `-` for consistency

### Code Block Annotations
- Added `bash` language annotation to installation code block
- Added `text` language annotation to usage/help code block
- Changed `(or)` to `# or` (proper bash comment)

### Wording Improvements
- "with same **names**" → "with the same **names**"
- "in given destination" → "in a given destination"
- "through this image files" → "through these image files"
- "which uses an awesome library" → "which in turn uses an awesome library called"
- Cleaned up punctuation in the last roadmap item

@RaviDasari can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)